### PR TITLE
Add Unused Dependencies Check

### DIFF
--- a/Plugins/explicitDependencyImportCheckPlugin/ExplicitDependencyImportCheckPlugin.swift
+++ b/Plugins/explicitDependencyImportCheckPlugin/ExplicitDependencyImportCheckPlugin.swift
@@ -61,7 +61,7 @@ extension ExplicitDependencyImportCheckPlugin {
         guard !unusedDependencies.isEmpty else { return [] }
 
         var warningText = "warning: \(unusedDependencies.count) Extraneous dependencies found for \(target.name) ⚠️⚠️\n"
-        warningText += unusedDependencies.map { "👉 \($0) is an extraneous depdnency" }
+        warningText += unusedDependencies.map { "👉 \($0) is an extraneous dependency" }
                                          .joined(separator: "\n")
 
         let echoTool = try context.tool(named: "echo")

--- a/Plugins/explicitDependencyImportCheckPlugin/ExplicitDependencyImportCheckPlugin.swift
+++ b/Plugins/explicitDependencyImportCheckPlugin/ExplicitDependencyImportCheckPlugin.swift
@@ -60,13 +60,13 @@ extension ExplicitDependencyImportCheckPlugin {
     ) throws -> [Command] {
         guard !unusedDependencies.isEmpty else { return [] }
 
-        var warningText = "warning: \(unusedDependencies.count) Unused dependencies found for \(target.name) ⚠️⚠️\n"
-        warningText += unusedDependencies.map { "👉 \($0) is an unused depdnency" }
+        var warningText = "warning: \(unusedDependencies.count) Extraneous dependencies found for \(target.name) ⚠️⚠️\n"
+        warningText += unusedDependencies.map { "👉 \($0) is an extraneous depdnency" }
                                          .joined(separator: "\n")
 
         let echoTool = try context.tool(named: "echo")
         return [.buildCommand(
-            displayName: "Unused Dependencies Report",
+            displayName: "Extraneous Dependencies Report",
             executable: echoTool.path,
             arguments: [warningText],
             environment: [:]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 **explicitDependencyImportCheck** is a Swift build plugin designed to help you enforce clean dependency management by ensuring that only explicitly declared dependencies are imported. Transitive dependencies can cause a range of problems, from bloated builds to fragile code. Swift provides the `--explicit-target-dependency-import-check` flag for this purpose, but it doesn’t work consistently with **XcodeBuild** – and that’s where this plugin steps in! 🚀
 
+This plugin also helps identify module dependencies that are unused and that can be removed from your Package.swift to speed up your builds even more! 
+
 ## 🌟 Features
 
 - **No More Transitive Dependencies**: Catch unwanted transitive imports and keep your code cleaner, faster, and more modular.
+- **No More Unused Dependencies**: Catch dependencies to modules that are unused and unnecessary.
 - **Swift Build Plugin**: Runs automatically during the Swift build process.
 - **Easy Integration**: Just add it to your project to start using!
 


### PR DESCRIPTION
Added check for the situation where a particular dependency is specified in `Package.swift`, but there is no import for the product inside the package it is a dependency of.